### PR TITLE
0.4 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,17 @@
-language: cpp
-compiler:
-  - clang
+language: julia
 notifications:
   email: peter.zion@gmail.com
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
+julia:
+    - release
+    - nightly
 before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
   - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
+  - sudo apt-get install libpcre3-dev -y
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:
   - julia -e 'Pkg.init()'
   - julia -e 'Pkg.clone(pwd()); Pkg.build("LibBSON")'
-  - julia -e 'Pkg.add("FactCheck"); Pkg.add("BinDeps")'
+  - julia -e 'Pkg.add("FactCheck"); Pkg.add("BinDeps"); Pkg.checkout("Compat")'
   - julia -e 'Pkg.test("LibBSON", coverage=true)'
 after_success:
-- if [ $JULIAVERSION = "juliareleases" ]; then julia -e 'cd(Pkg.dir("LibBSON")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
+- julia -e 'cd(Pkg.dir("LibBSON")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -18,26 +18,26 @@ Example Usage
 
     using LibBSON
 
-    bsonObject = BSONObject({
-        "null"=>nothing,
-        "bool"=>true,
-        "int"=>42,
-        "double"=>3.141,
-        "string"=>"Hello, Jérôme",
-        "oid"=>BSONOID(),
-        "minkey"=>:minkey,
-        "maxkey"=>:maxkey,
-        "array"=>{5.41, false}
-        })
+    bsonObject = BSONObject(Dict(
+        "null" => nothing,
+        "bool" => true,
+        "int" => 42,
+        "double" => 3.141,
+        "string" => "Hello, Jérôme",
+        "oid" => BSONOID(),
+        "minkey" => :minkey,
+        "maxkey" => :maxkey,
+        "array" => Any[5.41, false]
+        ))
     println(bsonObject)
     println(bsonObject["string"])
     for (k, v) in bsonObject
         println("$k => $v")
     end
-    bsonArray = BSONArray({
+    bsonArray = BSONArray(Any[
         "one",
-        {"key"=>6.7}
-        })
+        Dict("key" => 6.7)
+        ])
     for e in bsonArray
         println(e)
     end

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.3-
 BinDeps
+Compat
 @osx Homebrew

--- a/examples/readme.jl
+++ b/examples/readme.jl
@@ -1,0 +1,25 @@
+using LibBSON
+
+bsonObject = BSONObject(Dict(
+    "null" => nothing,
+    "bool" => true,
+    "int" => 42,
+    "double" => 3.141,
+    "string" => "Hello, Jérôme",
+    "oid" => BSONOID(),
+    "minkey" => :minkey,
+    "maxkey" => :maxkey,
+    "array" => Any[5.41, false]
+    ))
+println(bsonObject)
+println(bsonObject["string"])
+for (k, v) in bsonObject
+    println("$k => $v")
+end
+bsonArray = BSONArray(Any[
+    "one",
+    Dict("key" => 6.7)
+    ])
+for e in bsonArray
+    println(e)
+end

--- a/src/BSONArray.jl
+++ b/src/BSONArray.jl
@@ -27,7 +27,7 @@ type BSONArray
             Bool, (Ptr{Void}, Ptr{Uint8}, Uint32),
             buffer, data, length
             ) || error("bson_init_static: failure")
-        b = Base.unsafe_convert(Ptr{Void}, buffer)
+        b = Compat.unsafe_convert(Ptr{Void}, buffer)
         new(b, (_ref_, b))
     end
 
@@ -97,7 +97,7 @@ function append(bsonArray::BSONArray, val::BSONArray)
         length(keyCStr),
         childBuffer
         ) || error("bson_append_array_begin: failure")
-    childBSONArray = BSONArray(Base.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
+    childBSONArray = BSONArray(Compat.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
     for element in val
         append(childBSONArray, element)
     end
@@ -179,7 +179,7 @@ function append(bsonArray::BSONArray, val::Dict)
         length(keyCStr),
         childBuffer
         ) || error("bson_append_document_begin: failure")
-    childBSONObject = BSONObject(Base.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
+    childBSONObject = BSONObject(Compat.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
     for (k, v) in val
         append(childBSONObject, k, v)
     end
@@ -201,7 +201,7 @@ function append(bsonArray::BSONArray, val::Vector)
         length(keyCStr),
         childBuffer
         ) || error("bson_append_array_begin: failure")
-    childBSONArray = BSONArray(Base.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
+    childBSONArray = BSONArray(Compat.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
     for element in val
         append(childBSONArray, element)
     end

--- a/src/BSONArray.jl
+++ b/src/BSONArray.jl
@@ -27,7 +27,8 @@ type BSONArray
             Bool, (Ptr{Void}, Ptr{Uint8}, Uint32),
             buffer, data, length
             ) || error("bson_init_static: failure")
-        new(buffer, (_ref_, buffer))
+        b = Base.unsafe_convert(Ptr{Void}, buffer)
+        new(b, (_ref_, b))
     end
 
     BSONArray(_wrap_::Ptr{Void}, _ref_::Any) = new(_wrap_, _ref_)
@@ -96,7 +97,7 @@ function append(bsonArray::BSONArray, val::BSONArray)
         length(keyCStr),
         childBuffer
         ) || error("bson_append_array_begin: failure")
-    childBSONArray = BSONArray(convert(Ptr{Void}, childBuffer), childBuffer)
+    childBSONArray = BSONArray(Base.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
     for element in val
         append(childBSONArray, element)
     end
@@ -178,7 +179,7 @@ function append(bsonArray::BSONArray, val::Dict)
         length(keyCStr),
         childBuffer
         ) || error("bson_append_document_begin: failure")
-    childBSONObject = BSONObject(convert(Ptr{Void}, childBuffer), childBuffer)
+    childBSONObject = BSONObject(Base.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
     for (k, v) in val
         append(childBSONObject, k, v)
     end
@@ -200,7 +201,7 @@ function append(bsonArray::BSONArray, val::Vector)
         length(keyCStr),
         childBuffer
         ) || error("bson_append_array_begin: failure")
-    childBSONArray = BSONArray(convert(Ptr{Void}, childBuffer), childBuffer)
+    childBSONArray = BSONArray(Base.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
     for element in val
         append(childBSONArray, element)
     end

--- a/src/BSONError.jl
+++ b/src/BSONError.jl
@@ -7,17 +7,15 @@ type BSONError
 end
 export BSONError
 
-const domainDescs = @compat Dict{Int64,String}(1 => "JSON", 2 => "READER")
-const errorDescs = @compat Dict{Int64,String}(
-    1 => @compat Dict{Int64,String}(
+const domainDescs = Obj(1 => "JSON", 2 => "READER")
+const errorDescs = Obj(
+    1 => Obj(
         1 => "READ_CORRUPT_JS",
         2 => "READ_INVALID_PARAM",
-        3 => "READ_CB_FAILURE",
-        ),
-    2 => @compat Dict{Int64,String}(
-        1 => "BADFD",
-        ),
-    )
+        3 => "READ_CB_FAILURE"
+    ),
+    2 => Obj(1 => "BADFD")
+)
 
 convert(::Type{String}, bsonError::BSONError) = begin
     uint32s = reinterpret(Uint32, bsonError._wrap_)

--- a/src/BSONError.jl
+++ b/src/BSONError.jl
@@ -7,17 +7,17 @@ type BSONError
 end
 export BSONError
 
-const domainDescs = {1 => "JSON", 2 => "READER"}
-const errorDescs = {
-    1 => {
+const domainDescs = Obj(1 => "JSON", 2 => "READER")
+const errorDescs = Obj(
+    1 => Obj(
         1 => "READ_CORRUPT_JS",
         2 => "READ_INVALID_PARAM",
         3 => "READ_CB_FAILURE",
-        },
-    2 => {
+        ),
+    2 => Obj(
         1 => "BADFD",
-        },
-    }
+        ),
+    )
 
 convert(::Type{String}, bsonError::BSONError) = begin
     uint32s = reinterpret(Uint32, bsonError._wrap_)

--- a/src/BSONError.jl
+++ b/src/BSONError.jl
@@ -7,14 +7,14 @@ type BSONError
 end
 export BSONError
 
-const domainDescs = Obj(1 => "JSON", 2 => "READER")
-const errorDescs = Obj(
-    1 => Obj(
+const domainDescs = @compat Dict{Int64,String}(1 => "JSON", 2 => "READER")
+const errorDescs = @compat Dict{Int64,String}(
+    1 => @compat Dict{Int64,String}(
         1 => "READ_CORRUPT_JS",
         2 => "READ_INVALID_PARAM",
         3 => "READ_CB_FAILURE",
         ),
-    2 => Obj(
+    2 => @compat Dict{Int64,String}(
         1 => "BADFD",
         ),
     )

--- a/src/BSONError.jl
+++ b/src/BSONError.jl
@@ -7,15 +7,12 @@ type BSONError
 end
 export BSONError
 
-const domainDescs = Obj(1 => "JSON", 2 => "READER")
-const errorDescs = Obj(
-    1 => Obj(
+const domainDescs = @compat Dict{Int64,String}(1 => "JSON", 2 => "READER")
+const errorDescs = @compat Dict{Int64,Any}(1 => (@compat Dict{Int64,String}(
         1 => "READ_CORRUPT_JS",
         2 => "READ_INVALID_PARAM",
         3 => "READ_CB_FAILURE"
-    ),
-    2 => Obj(1 => "BADFD")
-)
+    )), 2 => @compat Dict{Int64,String}(1 => "BADFD"))
 
 convert(::Type{String}, bsonError::BSONError) = begin
     uint32s = reinterpret(Uint32, bsonError._wrap_)

--- a/src/BSONOID.jl
+++ b/src/BSONOID.jl
@@ -10,7 +10,8 @@ immutable BSONOID
             buffer,
             C_NULL
             )
-        new(buffer, buffer)
+            r = Base.unsafe_convert(Ptr{Uint8}, buffer)
+        new(r, r)
     end
 
     BSONOID(str::String) = begin
@@ -31,7 +32,8 @@ immutable BSONOID
             buffer,
             cstr
             )
-        new(buffer, buffer)
+            r = Base.unsafe_convert(Ptr{Uint8}, buffer)
+        new(r, r)
     end
 
     BSONOID(_wrap_::Ptr{Void}, _ref_::Any) = new(_wrap_, _ref_)
@@ -63,7 +65,7 @@ function convert(::Type{String}, oid::BSONOID)
         oid._wrap_,
         cstr
         )
-    return bytestring(convert(Ptr{Uint8}, cstr))
+    return bytestring(Base.unsafe_convert(Ptr{Uint8}, cstr))
 end
 export convert
 

--- a/src/BSONOID.jl
+++ b/src/BSONOID.jl
@@ -10,7 +10,7 @@ immutable BSONOID
             buffer,
             C_NULL
             )
-            r = Base.unsafe_convert(Ptr{Uint8}, buffer)
+            r = Compat.unsafe_convert(Ptr{Uint8}, buffer)
         new(r, r)
     end
 
@@ -32,7 +32,7 @@ immutable BSONOID
             buffer,
             cstr
             )
-            r = Base.unsafe_convert(Ptr{Uint8}, buffer)
+            r = Compat.unsafe_convert(Ptr{Uint8}, buffer)
         new(r, r)
     end
 
@@ -65,7 +65,7 @@ function convert(::Type{String}, oid::BSONOID)
         oid._wrap_,
         cstr
         )
-    return bytestring(Base.unsafe_convert(Ptr{Uint8}, cstr))
+    return bytestring(Compat.unsafe_convert(Ptr{Uint8}, cstr))
 end
 export convert
 

--- a/src/BSONObject.jl
+++ b/src/BSONObject.jl
@@ -43,7 +43,7 @@ type BSONObject
             Bool, (Ptr{Void}, Ptr{Uint8}, Uint32),
             buffer, data, length
             ) || error("bson_init_static: failure")
-        b = Base.unsafe_convert(Ptr{Void}, buffer)
+        b = Compat.unsafe_convert(Ptr{Void}, buffer)
         new(b, (_ref_, b))
     end
 
@@ -185,7 +185,7 @@ function append(bsonObject::BSONObject, key::String, val::Dict)
         length(keyCStr),
         childBuffer
         ) || error("bson_append_document_begin: failure")
-    childBSON = BSONObject(Base.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
+    childBSON = BSONObject(Compat.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
     for (k, v) in val
         append(childBSON, k, v)
     end
@@ -207,7 +207,7 @@ function append(bsonObject::BSONObject, key::String, val::Vector)
         length(keyCStr),
         childBuffer
         ) || error("bson_append_array_begin: failure")
-    childBSONArray = BSONArray(Base.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
+    childBSONArray = BSONArray(Compat.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
     for element in val
         append(childBSONArray, element)
     end

--- a/src/BSONObject.jl
+++ b/src/BSONObject.jl
@@ -43,7 +43,8 @@ type BSONObject
             Bool, (Ptr{Void}, Ptr{Uint8}, Uint32),
             buffer, data, length
             ) || error("bson_init_static: failure")
-        new(buffer, (_ref_, buffer))
+        b = Base.unsafe_convert(Ptr{Void}, buffer)
+        new(b, (_ref_, b))
     end
 
     BSONObject(_wrap_::Ptr{Void}, _owner_::Any) = new(_wrap_, _owner_)
@@ -184,7 +185,7 @@ function append(bsonObject::BSONObject, key::String, val::Dict)
         length(keyCStr),
         childBuffer
         ) || error("bson_append_document_begin: failure")
-    childBSON = BSONObject(convert(Ptr{Void}, childBuffer), childBuffer)
+    childBSON = BSONObject(Base.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
     for (k, v) in val
         append(childBSON, k, v)
     end
@@ -206,7 +207,7 @@ function append(bsonObject::BSONObject, key::String, val::Vector)
         length(keyCStr),
         childBuffer
         ) || error("bson_append_array_begin: failure")
-    childBSONArray = BSONArray(convert(Ptr{Void}, childBuffer), childBuffer)
+    childBSONArray = BSONArray(Base.unsafe_convert(Ptr{Void}, childBuffer), childBuffer)
     for element in val
         append(childBSONArray, element)
     end

--- a/src/LibBSON.jl
+++ b/src/LibBSON.jl
@@ -1,5 +1,7 @@
 module LibBSON
 
+using Compat
+
 include( "../deps/deps.jl")
 
 LIBBSON_VERSION = VersionNumber(
@@ -17,8 +19,9 @@ import Base.hash,
     Base.next,
     Base.done,
     Base.string,
-    Base.dict,
     Base.length
+
+typealias Obj @compat Dict{Any,Any}
 
 include("BSONOID.jl")
 include("BSONError.jl")

--- a/src/LibBSON.jl
+++ b/src/LibBSON.jl
@@ -21,8 +21,6 @@ import Base.hash,
     Base.string,
     Base.length
 
-typealias Obj @compat Dict{Any,Any}
-
 include("BSONOID.jl")
 include("BSONError.jl")
 include("BSONObject.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using FactCheck, LibBSON
 
+using LibBSON: Obj
+
 facts("BSONOID") do
     oid = BSONOID()
     @fact length(string(oid)) => 24
@@ -11,7 +13,7 @@ facts("BSONOID") do
 end
 
 facts("BSONObject") do
-    bsonObject = BSONObject({
+    bsonObject = BSONObject(Obj(
         "null"=>nothing,
         "bool"=>true,
         "int"=>42,
@@ -21,14 +23,14 @@ facts("BSONObject") do
         "minkey"=>:minkey,
         "maxkey"=>:maxkey,
         "regularSymbol"=>:symbol,
-        "subdict"=>{
+        "subdict"=> Obj(
             "key"=>"value"
-            },
-        "array"=>{"hello", {"foo"=>{56,false}}}
-        })
+            ),
+        "array"=> Any["hello", Obj("foo" => Any[56, false])]
+        ))
     @fact length(bsonObject) => 11
     @fact string(bsonObject) => "{ \"string\" : \"Hello, Jérôme\", \"anotherNull\" : null, \"null\" : null, \"regularSymbol\" : \"symbol\", \"bool\" : true, \"int\" : 42, \"minkey\" : { \"\$minKey\" : 1 }, \"maxkey\" : { \"\$maxKey\" : 1 }, \"array\" : [ \"hello\", { \"foo\" : [ 56, false ] } ], \"subdict\" : { \"key\" : \"value\" }, \"double\" : 3.141000 }"
-    @fact dict(bsonObject) => {"string"=>"Hello, Jérôme","anotherNull"=>nothing,"null"=>nothing,"regularSymbol"=>"symbol","bool"=>true,"int"=>42,"minkey"=>:minkey,"maxkey"=>:maxkey,"array"=>{"hello",{"foo"=>{56,false}}},"subdict"=>{"key"=>"value"},"double"=>3.141}
+    @fact dict(bsonObject) => Obj("string"=>"Hello, Jérôme","anotherNull"=>nothing,"null"=>nothing,"regularSymbol"=>"symbol","bool"=>true,"int"=>42,"minkey"=>:minkey,"maxkey"=>:maxkey,"array"=>Any["hello",Obj("foo"=>Any[56,false])],"subdict"=>Obj("key"=>"value"),"double"=>3.141)
     append(bsonObject, "int64", -57)
     @fact bsonObject["int64"] => -57
     append(bsonObject, "int32", 0x12345678)
@@ -36,7 +38,7 @@ facts("BSONObject") do
 
     context("BSONObject with OID") do
         oid = BSONOID()
-        bsonObject = BSONObject({"oid"=>oid})
+        bsonObject = BSONObject(Obj("oid" => oid))
         @fact (length(string(bsonObject)) > 0) => true
         @fact (bsonObject["oid"] == oid) => true
     end
@@ -47,8 +49,8 @@ facts("BSONObject") do
     end
 
     context("BSONObject containing BSONObject") do
-        subBSONObject = BSONObject({"key"=>"value"})
-        bsonObject = BSONObject({"sub"=>subBSONObject})
+        subBSONObject = BSONObject(Obj("key"=>"value"))
+        bsonObject = BSONObject(Obj("sub"=>subBSONObject))
         @fact string(bsonObject) => "{ \"sub\" : { \"key\" : \"value\" } }"
         @fact string(bsonObject["sub"]) => "{ \"key\" : \"value\" }"
     end
@@ -68,11 +70,11 @@ facts("BSONArray") do
         ])
     @fact length(bsonArray) => 9
     @fact string(bsonArray) => "[ null, true, 42, 3.141000, \"Hello, Jérôme\", null, { \"\$minKey\" : 1 }, { \"\$maxKey\" : 1 }, \"symbol\" ]"
-    @fact vector(bsonArray) => {nothing,true,42,3.141,"Hello, Jérôme",nothing,:minkey,:maxkey,"symbol"}
+    @fact vector(bsonArray) => Any[nothing,true,42,3.141,"Hello, Jérôme",nothing,:minkey,:maxkey,"symbol"]
     append(bsonArray, BSONArray([false]))
     append(bsonArray, -67)
     append(bsonArray, ["hello", 6.7])
-    @fact vector(bsonArray) => {nothing,true,42,3.141,"Hello, Jérôme",nothing,:minkey,:maxkey,"symbol",{false},-67,{"hello",6.7}}
+    @fact vector(bsonArray) => Any[nothing,true,42,3.141,"Hello, Jérôme",nothing,:minkey,:maxkey,"symbol",Any[false],-67,["hello",6.7]]
 
     bsonArray = BSONArray()
     append(bsonArray, BSONOID())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,4 @@
-using FactCheck, LibBSON
-
-using LibBSON: Obj
+using FactCheck, LibBSON, Compat
 
 facts("BSONOID") do
     oid = BSONOID()
@@ -13,7 +11,7 @@ facts("BSONOID") do
 end
 
 facts("BSONObject") do
-    bsonObject = BSONObject(Obj(
+    bsonObject = BSONObject(@compat Dict{Any,Any}(
         "null"=>nothing,
         "bool"=>true,
         "int"=>42,
@@ -23,14 +21,14 @@ facts("BSONObject") do
         "minkey"=>:minkey,
         "maxkey"=>:maxkey,
         "regularSymbol"=>:symbol,
-        "subdict"=> Obj(
+        "subdict"=> (@compat Dict{Any,Any}(
             "key"=>"value"
-            ),
-        "array"=> Any["hello", Obj("foo" => Any[56, false])]
+            )),
+        "array"=> Any["hello", (@compat Dict{Any,Any}("foo" => Any[56, false]))]
         ))
     @fact length(bsonObject) => 11
     @fact string(bsonObject) => "{ \"string\" : \"Hello, Jérôme\", \"anotherNull\" : null, \"null\" : null, \"regularSymbol\" : \"symbol\", \"bool\" : true, \"int\" : 42, \"minkey\" : { \"\$minKey\" : 1 }, \"maxkey\" : { \"\$maxKey\" : 1 }, \"array\" : [ \"hello\", { \"foo\" : [ 56, false ] } ], \"subdict\" : { \"key\" : \"value\" }, \"double\" : 3.141000 }"
-    @fact dict(bsonObject) => Obj("string"=>"Hello, Jérôme","anotherNull"=>nothing,"null"=>nothing,"regularSymbol"=>"symbol","bool"=>true,"int"=>42,"minkey"=>:minkey,"maxkey"=>:maxkey,"array"=>Any["hello",Obj("foo"=>Any[56,false])],"subdict"=>Obj("key"=>"value"),"double"=>3.141)
+    @fact dict(bsonObject) => @compat Dict{Any,Any}("string"=>"Hello, Jérôme","anotherNull"=>nothing,"null"=>nothing,"regularSymbol"=>"symbol","bool"=>true,"int"=>42,"minkey"=>:minkey,"maxkey"=>:maxkey,"array"=>Any["hello",(@compat Dict{Any,Any}("foo"=>Any[56,false]))],"subdict"=>(@compat Dict{Any,Any}("key"=>"value")),"double"=>3.141)
     append(bsonObject, "int64", -57)
     @fact bsonObject["int64"] => -57
     append(bsonObject, "int32", 0x12345678)
@@ -38,7 +36,7 @@ facts("BSONObject") do
 
     context("BSONObject with OID") do
         oid = BSONOID()
-        bsonObject = BSONObject(Obj("oid" => oid))
+        bsonObject = BSONObject(@compat Dict{Any,Any}("oid" => oid))
         @fact (length(string(bsonObject)) > 0) => true
         @fact (bsonObject["oid"] == oid) => true
     end
@@ -49,8 +47,8 @@ facts("BSONObject") do
     end
 
     context("BSONObject containing BSONObject") do
-        subBSONObject = BSONObject(Obj("key"=>"value"))
-        bsonObject = BSONObject(Obj("sub"=>subBSONObject))
+        subBSONObject = BSONObject(@compat Dict{Any,Any}("key"=>"value"))
+        bsonObject = BSONObject(@compat Dict{Any,Any}("sub"=>subBSONObject))
         @fact string(bsonObject) => "{ \"sub\" : { \"key\" : \"value\" } }"
         @fact string(bsonObject["sub"]) => "{ \"key\" : \"value\" }"
     end


### PR DESCRIPTION
Tested in 0.3 and 0.4. Used a `typealias` to only make one reference to `@compat`.