### PR TITLE
Fix Date and DateTime: convert UNIX epoch seconds to milliseconds

### DIFF
--- a/src/BSONArray.jl
+++ b/src/BSONArray.jl
@@ -90,7 +90,7 @@ end
 using Base.Dates: datetime2unix
 function append(bsonArray::BSONArray, val::Union{Date,DateTime})
     keyCStr = bytestring(string(length(bsonArray)))
-    ts = typeof(val) == Date ? datetime2unix(DateTime(val)) : datetime2unix(val)
+    ts = (typeof(val) == Date ? datetime2unix(DateTime(val)) : datetime2unix(val)) * 1000
     ccall(
         (:bson_append_date_time, libbson),
         Bool, (Ptr{Void}, Ptr{UInt8}, Cint, Clong),

--- a/src/BSONIter.jl
+++ b/src/BSONIter.jl
@@ -184,7 +184,7 @@ function value(bsonIter::BSONIter)
             Int64, (Ptr{UInt8}, ),
             bsonIter._wrap_
             )
-        return Dates.unix2datetime(ts)
+        return Dates.unix2datetime(ts / 1000)
     elseif ty == BSON_TYPE_NULL
         return nothing
     elseif ty == BSON_TYPE_MINKEY

--- a/src/BSONObject.jl
+++ b/src/BSONObject.jl
@@ -106,7 +106,7 @@ end
 using Base.Dates: datetime2unix
 function append(bsonObject::BSONObject, key::AbstractString, val::Union{Date,DateTime})
     keyCStr = bytestring(key)
-    ts = typeof(val) == Date ? datetime2unix(DateTime(val)) : datetime2unix(val)
+    ts = (typeof(val) == Date ? datetime2unix(DateTime(val)) : datetime2unix(val)) * 1000
     ccall(
         (:bson_append_date_time, libbson),
         Bool, (Ptr{Void}, Ptr{UInt8}, Cint, Clong),


### PR DESCRIPTION
The Libbson acceps UNIX epoch in miliseconds, not in seconds [1].

[1] http://api.mongodb.org/libbson/current/bson_append_date_time.html