### PR TITLE
allow Julia to take ownership of BSONOID from BSONIter

### DIFF
--- a/src/BSONIter.jl
+++ b/src/BSONIter.jl
@@ -199,14 +199,14 @@ function value(bsonIter::BSONIter)
             C_NULL
             )))
     elseif ty == BSON_TYPE_OID
-        return BSONOID(
-            ccall(
+        data = Array(UInt8, 12)
+        ptr = ccall(
                 (:bson_iter_oid, libbson),
-                Ptr{Void}, (Ptr{UInt8},),
+                Ptr{UInt8}, (Ptr{UInt8},),
                 bsonIter._wrap_
-                ),
-            bsonIter
-            )
+                )
+        unsafe_copy!(pointer(data), ptr, 12)
+        return BSONOID(data)
     elseif ty == BSON_TYPE_DOCUMENT
         length = Array(UInt32, 1)
         data = Array(Ptr{UInt8}, 1)

--- a/src/BSONOID.jl
+++ b/src/BSONOID.jl
@@ -36,7 +36,7 @@ immutable BSONOID
         new(r, buffer)
     end
 
-    BSONOID(_wrap_::Ptr{Void}, _ref_::Any) = new(_wrap_, _ref_)
+    BSONOID(_ref_::Any) = new(pointer(_ref_), _ref_)
 end
 export BSONOID
 


### PR DESCRIPTION
This allow Julia to internally store BSONOID objects obtained via a BSONIter.  Previously, calling C function bson_iter_next() may overwrite the memory location pointed to in BSONOID.  For example, when multiple documents are read into Julia Dict's, the BSONOID's could be corrupted.

Note that calling C function bson_iter_oid() does not require freeing the memory pointed to by the return pointer later, implying that it is freed automatically by the C API.