### PR TITLE
Fix DateTime functions

### DIFF
--- a/src/BSONArray.jl
+++ b/src/BSONArray.jl
@@ -90,7 +90,7 @@ end
 using Base.Dates: datetime2unix
 function append(bsonArray::BSONArray, val::DateTime)
     keyCStr = string(length(bsonArray))
-    ts = round(Int64, datetime2unix(val))*1000)
+    ts = round(Int64, datetime2unix(val)*1000)
     ccall(
         (:bson_append_date_time, libbson),
         Bool, (Ptr{Void}, Ptr{UInt8}, Cint, Clonglong),

--- a/src/BSONArray.jl
+++ b/src/BSONArray.jl
@@ -88,17 +88,20 @@ function append(bsonArray::BSONArray, val::Real)
         ) || error("libBSON: overflow")
 end
 using Base.Dates: datetime2unix
-function append(bsonArray::BSONArray, val::Union{Date,DateTime})
+function append(bsonArray::BSONArray, val::DateTime)
     keyCStr = string(length(bsonArray))
-    ts = (typeof(val) == Date ? datetime2unix(DateTime(val)) : datetime2unix(val)) * 1000
+    ts = round(Int64, datetime2unix(val))*1000)
     ccall(
         (:bson_append_date_time, libbson),
-        Bool, (Ptr{Void}, Ptr{UInt8}, Cint, Clong),
+        Bool, (Ptr{Void}, Ptr{UInt8}, Cint, Clonglong),
         bsonArray._wrap_,
         keyCStr,
         length(keyCStr),
         ts
         ) || error("libBSON: overflow")
+end
+function append(bsonArray::BSONArray, val::Date)
+    append(bsonArray, DateTime(val))
 end
 function append(bsonArray::BSONArray, val::BSONArray)
     keyCStr = string(length(bsonArray))

--- a/src/BSONObject.jl
+++ b/src/BSONObject.jl
@@ -117,17 +117,20 @@ function append(bsonObject::BSONObject, key::AbstractString, val::Real)
         ) || error("libBSON: overflow")
 end
 using Base.Dates: datetime2unix
-function append(bsonObject::BSONObject, key::AbstractString, val::Union{Date,DateTime})
+function append(bsonObject::BSONObject, key::AbstractString, val::DateTime)
     keyCStr = string(key)
-    ts = (typeof(val) == Date ? datetime2unix(DateTime(val)) : datetime2unix(val)) * 1000
+    ts = round(Int64, datetime2unix(val)*1000)
     ccall(
         (:bson_append_date_time, libbson),
-        Bool, (Ptr{Void}, Ptr{UInt8}, Cint, Clong),
+        Bool, (Ptr{Void}, Ptr{UInt8}, Cint, Clonglong),
         bsonObject._wrap_,
         keyCStr,
         length(keyCStr),
         ts
         ) || error("libBSON: overflow")
+end
+function append(bsonObject::BSONObject, key::AbstractString, val::Date)
+    append(bsonObject, key, DateTime(val))
 end
 function append(bsonObject::BSONObject, key::AbstractString, val::BSONObject)
     keyCStr = string(key)


### PR DESCRIPTION
The C function takes an `int64_t`, which corresponds to a `Clonglong` in julia. I also removed the ternary in favor of using dispatch instead when appending a `Date`.