### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ notifications:
   email: peter.zion@gmail.com
 julia:
     - 0.4
-    - release
+    - 0.5
 #    - nightly
 before_install:
   - sudo apt-get update -qq -y


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.4 so it should continue to be tested